### PR TITLE
Rewrite script to use vendor packages if possible

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -4,16 +4,49 @@
 # ./run_tests.sh unit # Runs unit tests
 # ./run_test.sh integration # Runs integration tests
 
-module_list=$(pip list --format=columns | awk '{print $1'})
+cd "$( dirname "$0" )"
 
-# Install modules that arent present, save time instead of reinstalling everytime
-for i in $(cat requirements-dev.txt);
-  do
-    if ! grep -x $i <<< "$module_list" 1>/dev/null; then
-        pip install $i
-    fi
-  done
+# output only lines unique to "file" 1 - the requirements file
+function list_missing_modules {
+  comm -2 -3 \
+  <( sort ./requirements-dev.txt ) \
+  <( pip list format=columns | awk '$0=$1' | sort )
+}
 
-export PYTHONPATH=$(pwd)/ouroboros
+# create associative array of missing modules
+declare -A missing_modules
+while read module
+do
+  missing_modules[$module]=1
+done < <( list_missing_modules )
 
-$(which python3) -m pytest tests/$1 -v --cov-report term-missing --cov=$PYTHONPATH 
+vendor=""
+which lsb_release >/dev/null 2>&1 && vendor=$( lsb_release -is )
+sudo=""
+[[ "$( id -u )" != 0 ]] && sudo="sudo"
+
+# try to install packages using vendor package manager
+shopt -qs nocasematch extglob
+case "$vendor" in
+  @(?(open)suse) )
+    for m in "${!missing_modules[@]}"
+    do
+      $sudo zypper install -y "python3-$m" && unset missing_modules["$m"]
+    done
+    ;;
+  ubuntu )
+    for m in "${!missing_modules[@]}"
+    do
+      $sudo apt install -y "python3-$m" && unset missing_modules["$m"]
+    done
+    ;;
+esac
+shopt -qu nocasematch extglob
+
+# Generate a requirement "file" containing only remaining missing modules
+# If everything is installed, file will be empty and pip exits quietly
+pip install --requirement <( for m in  "${!missing_modules[@]}"; do echo "$m"; done )
+
+export PYTHONPATH="$(pwd)/ouroboros"
+
+python3 -m pytest "tests/$1" -v --cov-report term-missing --cov="$PYTHONPATH"


### PR DESCRIPTION
I started by quoting variables, fixing the misplaced quote in the awk command, and simplifying the script --but then things got a little out of hand as I really wanted to use my vendor's python packages where possible instead of installing with pip. :D

So, there's support for OpenSUSE, SLE, and Ubuntu packages in there now.  It'll still fall back to `pip` for any deps which aren't able to be installed with `zypper`/`apt` (and for systems which aren't SUSE or Ubuntu).