### PR TITLE
Move api client out of cli.py

### DIFF
--- a/ouroboros/cli.py
+++ b/ouroboros/cli.py
@@ -46,7 +46,6 @@ def get_interval_env():
 
 def parse(sysargs):
     """Declare command line options"""
-    global api_client
     parser = argparse.ArgumentParser(description='ouroboros',
                                      epilog='Example: python3 main.py -u tcp://1.2.3.4:5678 -i 20 -m container1 container2 -l warn')
 

--- a/ouroboros/cli.py
+++ b/ouroboros/cli.py
@@ -1,10 +1,7 @@
 from os import environ
 import argparse
-import docker
 import re
 import defaults
-
-api_client = None
 
 
 def checkURI(uri):
@@ -79,5 +76,4 @@ def parse(sysargs):
         if args.url is not defaults.LOCAL_UNIX_SOCKET:
             args.url = args.url if checkURI(args.url) else defaults.LOCAL_UNIX_SOCKET
 
-    api_client = docker.APIClient(base_url=args.url)
     return args

--- a/ouroboros/container.py
+++ b/ouroboros/container.py
@@ -1,5 +1,4 @@
 import logging
-import cli
 
 log = logging.getLogger(__name__)
 
@@ -18,37 +17,37 @@ def new_container_properties(old_container, new_image):
     return props
 
 
-def running():
+def running(api_client):
     """Return running container objects list"""
     running_containers = []
     try:
-        for container in cli.api_client.containers(
+        for container in api_client.containers(
                 filters={'status': 'running'}):
             if 'ouroboros' not in container['Image']:
                 running_containers.append(
-                    cli.api_client.inspect_container(container))
+                    api_client.inspect_container(container))
         return running_containers
     except BaseException:
         log.critical(
-            f'Can\'t connect to Docker API at {cli.api_client.base_url}')
+            f'Can\'t connect to Docker API at {api_client.base_url}')
 
 
-def to_monitor(monitor=None):
+def to_monitor(monitor=None, api_client=None):
     """Return filtered running container objects list"""
     running_containers = []
     try:
         if monitor:
-            for container in cli.api_client.containers(
+            for container in api_client.containers(
                     filters={'name': monitor, 'status': 'running'}):
                 running_containers.append(
-                    cli.api_client.inspect_container(container))
+                    api_client.inspect_container(container))
         else:
-            running_containers.extend(running())
+            running_containers.extend(running(api_client))
         log.info(f'{len(running_containers)} running container(s) matched filter')
         return running_containers
     except BaseException:
         log.critical(
-            f'Can\'t connect to Docker API at {cli.api_client.base_url}')
+            f'Can\'t connect to Docker API at {api_client.base_url}')
 
 
 def get_name(container_object):
@@ -56,24 +55,24 @@ def get_name(container_object):
     return container_object['Name'].replace('/', '')
 
 
-def stop(container_object):
+def stop(container_object, api_client):
     """Stop out of date container"""
     log.debug(f'Stopping container: {get_name(container_object)}')
-    return cli.api_client.stop(container_object)
+    return api_client.stop(container_object)
 
 
-def remove(container_object):
+def remove(container_object, api_client):
     """Remove out of date container"""
     log.debug(f'Removing container: {get_name(container_object)}')
-    return cli.api_client.remove_container(container_object)
+    return api_client.remove_container(container_object)
 
 
-def create_new(config):
+def create_new(config, api_client):
     """Create new container with latest image"""
-    return cli.api_client.create_container(**config)
+    return api_client.create_container(**config)
 
 
-def start(container_object):
+def start(container_object, api_client):
     """Start newly created container with latest image"""
     log.debug(f"Starting container: {container_object['Id']}")
-    return cli.api_client.start(container_object)
+    return api_client.start(container_object)

--- a/ouroboros/image.py
+++ b/ouroboros/image.py
@@ -1,27 +1,31 @@
 from os import environ
 import logging
-import cli
 
 log = logging.getLogger(__name__)
+
 
 def check_credentials():
     """Returns dict of credentials if environment variable 'REPO_USER' and 'REPO_PASS' are set"""
     if environ.get('REPO_USER') and environ.get('REPO_PASS'):
-        return {'username': environ['REPO_USER'], 'password': environ['REPO_PASS']}
+        return {'username': environ['REPO_USER'],
+                'password': environ['REPO_PASS']}
     return {}
 
-def pull_latest(image):
+
+def pull_latest(image, api_client):
     """Return tag of latest image pulled"""
     latest_image = image['RepoTags'][0].split(':')[0] + ':latest'
     log.debug(f'Pulling image: {latest_image}')
-    cli.api_client.pull(latest_image, auth_config=check_credentials())
-    return cli.api_client.inspect_image(latest_image)
+    api_client.pull(latest_image, auth_config=check_credentials())
+    return api_client.inspect_image(latest_image)
+
 
 def is_up_to_date(old_sha, new_sha):
     """Returns boolean if old and new image digests match"""
     return old_sha == new_sha
 
-def remove(old_image):
+
+def remove(old_image, api_client):
     """Deletes old image after container is updated"""
     log.info(f"Removing image: {old_image['RepoTags'][0]}")
-    return cli.api_client.remove_image(old_image)
+    return api_client.remove_image(old_image)

--- a/tests/integration/main_test.py
+++ b/tests/integration/main_test.py
@@ -55,7 +55,7 @@ def test_main(mocker):
                        'RUNONCE': 'true',
                        'CLEANUP': 'true',
                        'MONITOR': test_container_name})
-    mocker.patch('ouroboros.cli.api_client', api_client)
+    #mocker.patch('ouroboros.cli.api_client', api_client)
 
     with pytest.raises(SystemExit):
         assert imp.load_source('__main__', 'ouroboros/main.py') == SystemExit

--- a/tests/integration/main_test.py
+++ b/tests/integration/main_test.py
@@ -55,8 +55,6 @@ def test_main(mocker):
                        'RUNONCE': 'true',
                        'CLEANUP': 'true',
                        'MONITOR': test_container_name})
-    #mocker.patch('ouroboros.cli.api_client', api_client)
-
     with pytest.raises(SystemExit):
         assert imp.load_source('__main__', 'ouroboros/main.py') == SystemExit
 


### PR DESCRIPTION
This PR moves `api_client` out of `cli.py` and instead creates an `api_client` in the main loop. Since `cli.py` no longer provides the `api_client`, the `api_client` is a now a function argument for functions that need a client. This makes mocking/testing significantly easier.