### PR TITLE
Disable pip cache in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,5 @@ FROM python:3.6-alpine
 
 COPY . /app
 WORKDIR /app
-RUN pip install .
+RUN pip install --no-cache-dir .
 ENTRYPOINT ["ouroboros"]


### PR DESCRIPTION
It doesn't do much of a difference, but still saves 1MB in the pip install layer.

Without --no-cache-dir:
```
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
4a889526f024        23 seconds ago      /bin/sh -c #(nop)  ENTRYPOINT ["ouroboros"]     0B
fc1bbdc7d8d9        23 seconds ago      /bin/sh -c pip install .                        11.2MB
f52b1822a574        29 seconds ago      /bin/sh -c #(nop) WORKDIR /app                  0B
ff68c7715a92        29 seconds ago      /bin/sh -c #(nop) COPY dir:b7a988c2253999fea…   21.4kB
```

With --no-cache-dir:
```
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
fc05a396dea7        4 seconds ago       /bin/sh -c #(nop)  ENTRYPOINT ["ouroboros"]     0B
4cfeeb1816ee        4 seconds ago       /bin/sh -c pip install --no-cache-dir .         10.2MB
1d752126f43d        10 seconds ago      /bin/sh -c #(nop) WORKDIR /app                  0B
8ea197c11b15        11 seconds ago      /bin/sh -c #(nop) COPY dir:8a8a1d6ff52947334…   21.4kB
```